### PR TITLE
Change checksum function to void, as it returns no value

### DIFF
--- a/DYIRDaikin.cpp
+++ b/DYIRDaikin.cpp
@@ -222,7 +222,7 @@ void DYIRDaikin::description()
 }
 
 //private function
-uint8_t DYIRDaikin::checksum()
+void DYIRDaikin::checksum()
 {
 	uint8_t sum = 0;
 	uint8_t i;

--- a/DYIRDaikin.h
+++ b/DYIRDaikin.h
@@ -56,7 +56,7 @@ private:
     byte vModeTable[5] = { 0x6,0x3,0x2,0x4,0x00};
 //
     uint8_t	irReceiveData[25] = {0};
-    uint8_t checksum();
+    void checksum();
 //
     void receivedIRUpdateToSendBuffer(uint8_t *recvData);
 };


### PR DESCRIPTION
This creates random crashes on certain platforms. 