### PR TITLE
Fix temperature ranges for ARC

### DIFF
--- a/DYIRDaikin.cpp
+++ b/DYIRDaikin.cpp
@@ -167,10 +167,25 @@ uint8_t DYIRDaikin::getFan()
 
 void DYIRDaikin::setTemp(uint8_t temp)
 {
-	if (temp >= 18 && temp<=32)
-	{
-		daikin[14] = (temp)*2;
-		checksum();
+	switch (getMode()) {
+		case 1:	// cool
+			if (temp >= 18 && temp <= 32) {
+				daikin[14] = temp * 2;
+				checksum();
+			}
+			break;
+		case 3:	// heat
+			if (temp >= 10 && temp <= 30) {
+				daikin[14] = temp * 2;
+				checksum();
+			}
+			break;
+		case 4:	// auto
+			if (temp >= 18 && temp <= 30) {
+				daikin[14] = temp * 2;
+				checksum();
+			}
+			break;
 	}
 }
 

--- a/DYIRDaikin.h
+++ b/DYIRDaikin.h
@@ -22,7 +22,7 @@ public:
 	void setSwingLR(uint8_t state);
     void setMode(uint8_t mode);//0 FAN, 1 COOL, 2 DRY, 3 HEAT,4 AUTO
     void setFan(uint8_t speed);// 0~4 speed,5 auto,6 moon
-    void setTemp(uint8_t temp);//23 ~ 33
+    void setTemp(uint8_t temp);// 18-32 cool, 10-30 heat, 18-30 auto
     void sendCommand();
     void dump();
     void description();
@@ -62,4 +62,3 @@ private:
 };
 
 #endif
-

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Default is pin 3 when you use `begin()`.Remeber! SOFT IR must assign pin by `beg
 - setSwing_off();//turn off swing
 - setMode(int mode);//0=FAN, 1=COOL, 2=DRY, 3=HEAT(if you have one)
 - setFan(int speed);// 0~4=speed(1,2,3,4,5),5=auto,6=moon
-- setTemp(int temp);//18 ~ 32 Celsius,if you using Fahrenheit ,maybe to enter Fahrenheit.
+- setTemp(int temp);// 18-32 cool, 10-30 heat, 18-30 auto
 - sendCommand();
 - decode();//decode ir
 - description();//print switch state
@@ -99,7 +99,7 @@ Default is pin 3 when you use `begin()`.Remeber! SOFT IR must assign pin by `beg
 - setSwing_on();//turn on swing
 - setSwing_off();//turn off swing
 - setFan(int speed);// 0.Low 1.High
-- setTemp(int temp);//18 ~ 36 Celsius,if you using Fahrenheit ,maybe to enter Fahrenheit.
+- setTemp(int temp);//18 ~ 36 Celsius
 - sendCommand();
 
  ## Execute function:
@@ -130,4 +130,3 @@ Default is pin 3 when you use `begin()`.Remeber! SOFT IR must assign pin by `beg
 ## Donate
 
 [![Donate with PayPal](https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png)](https://www.paypal.me/dannytwdanny)
-


### PR DESCRIPTION
Fixes #7 
Corrects the temperature restrictions in setTemp, removes reference to Fahrenheit in README, as the firmware doesn't support it (the conversion is done in the remote, and always sent in Celsius) 