### PR TITLE
Remove the Arduino_ prefix in library name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DY_Daikin
-version=1.1.0
+version=1.2.0
 author=Danny
 maintainer=danny@35g.tw
 sentence=

--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Arduino_DY_Daikin
+name=DY_Daikin
 version=1.1.0
 author=Danny
 maintainer=danny@35g.tw


### PR DESCRIPTION
Hi :) I'm a big fan of this library which I'm using in a personal setup in conjunction with [Arduino Cloud](https://cloud.arduino.cc).

I would like to be able to install it from the Arduino IDE, command line tool or web editor but unfortunately it can't be indexed in the [Arduino library registry](https://github.com/arduino/library-registry) because the name does not comply with the [Library Specification](https://arduino.github.io/arduino-cli/0.28/library-specification/) rules. In particular, the `Arduino_` prefix is reserved for official Arduino libs.

This PR renames the library so that its name does not include the `Arduino_` prefix. There's no need to rename the repository.